### PR TITLE
 [Fix] PR 작성 후 commit 추가 시 리뷰어 다시 지정되는 오류 수정

### DIFF
--- a/.github/actions/reviewers/action.js
+++ b/.github/actions/reviewers/action.js
@@ -13,7 +13,7 @@ try {
   const response = await octokit.rest.pulls.listRequestedReviewers({
     owner,
     repo,
-    pull_number: pull_number - 1,
+    pull_number,
   })
 
   if (response.data.users.length < 2) {

--- a/.github/actions/reviewers/action.js
+++ b/.github/actions/reviewers/action.js
@@ -10,6 +10,14 @@ try {
   const { owner, repo } = context.repo
   const pull_number = context.issue.number
 
+  const response = await octokit.rest.pulls.listRequestedReviewers({
+    owner,
+    repo,
+    pull_number: pull_number - 1,
+  })
+
+  console.log(response)
+
   await octokit.rest.pulls.requestReviewers({
     owner,
     repo,


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->

## 💡 핵심적으로 구현된 사항
- pr 작성 후 commit 다시 push하면 기존의 리뷰어가 있는 경우에는 리뷰어가 다시 지정되지 않습니다

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
