### PR TITLE
 [Feat ✏️] InputBox 구성 컴포넌트 및 InputBoxMain 컴포넌트 생성

### DIFF
--- a/src/components/InputBox/InputBox.tsx
+++ b/src/components/InputBox/InputBox.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from "react"
+
+import { Flex, FlexProps } from "@chakra-ui/react"
+
+import InputContent from "./components/InputContent"
+import InputFooter from "./components/InputFooter"
+import InputLabel from "./components/InputHeader"
+
+interface InputBoxMainProps extends FlexProps {
+  children: ReactNode
+}
+
+const InputBoxMain = ({ children, ...props }: InputBoxMainProps) => {
+  return (
+    <Flex
+      flexDir="column"
+      {...props}>
+      {children}
+    </Flex>
+  )
+}
+
+export const InputBox = Object.assign(InputBoxMain, {
+  Header: InputLabel,
+  Content: InputContent,
+  Footer: InputFooter,
+})

--- a/src/components/InputBox/components/InputContent.tsx
+++ b/src/components/InputBox/components/InputContent.tsx
@@ -1,11 +1,17 @@
+import { forwardRef } from "react"
+
 import { Box, Input, InputProps } from "@chakra-ui/react"
 
-const InputContent = ({ ...props }: InputProps) => {
+const InputContent = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   return (
     <Box>
-      <Input {...props}></Input>
+      <Input
+        ref={ref}
+        {...props}></Input>
     </Box>
   )
-}
+})
+
+InputContent.displayName = "InputContent"
 
 export default InputContent

--- a/src/components/InputBox/components/InputContent.tsx
+++ b/src/components/InputBox/components/InputContent.tsx
@@ -1,0 +1,11 @@
+import { Box, Input, InputProps } from "@chakra-ui/react"
+
+const InputContent = ({ ...props }: InputProps) => {
+  return (
+    <Box>
+      <Input {...props}></Input>
+    </Box>
+  )
+}
+
+export default InputContent

--- a/src/components/InputBox/components/InputFooter.tsx
+++ b/src/components/InputBox/components/InputFooter.tsx
@@ -1,0 +1,15 @@
+import { Box, Text } from "@chakra-ui/react"
+
+const InputFooter = ({ text }: { text: string }) => {
+  return (
+    <Box>
+      <Text
+        fontSize="1rem"
+        color="grey">
+        {text}
+      </Text>
+    </Box>
+  )
+}
+
+export default InputFooter

--- a/src/components/InputBox/components/InputHeader.tsx
+++ b/src/components/InputBox/components/InputHeader.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react"
+
+import { Box } from "@chakra-ui/react"
+
+interface InputHeaderProps {
+  name: string
+  children: ReactNode
+}
+
+const InputHeader = ({ name, children }: InputHeaderProps) => {
+  return (
+    <Box>
+      <label htmlFor={name}>{children}</label>
+    </Box>
+  )
+}
+
+export default InputHeader


### PR DESCRIPTION
## #️⃣연관된 이슈
#72 
<!-- #이슈번호, #이슈번호-->

## 💡 핵심적으로 구현된 사항
<img width="511" alt="image" src="https://github.com/side-peek/sidepeek_frontend/assets/120625398/453c57fa-fb30-40e0-816e-a5035d9c3a66">

- form의 한 input section에 필요한 요소들을 합성 컴포넌트 방식으로 구현했습니다
```
 <InputBox gap='0.5rem'>
        <InputBox.Header name="name">
          <Text>제목</Text>
        </InputBox.Header>
        <InputBox.Content id='name' {...register('name', ...)} />
        <InputBox.Footer text='제목은 필수입니다'/>
      </InputBox>
    </div>
```

## ➕ 그 외에 추가적으로 구현된 사항
없음

## 🤔 테스트,검증 && 고민 사항
- 그냥 일반 props로 전달하는 방법도 크게 복잡하지 않을 것 같긴 하지만, Header / Content / Footer 라는 의미가 잘 분리되고, 에러 메시지 추가 등 확장성을 고려해 봤을 때 좋을 것 같아 합성 컴포넌트 방식으로 구현했습니다

-  label 태그와 input을 연결하기 위해서 label의 `for(htmlFor)`과 input의 `id`는 동일한 값이 들어가야 하는데, 합성 컴포넌트 방식이다 보니 동일한 값을 가지게 강제하려면 Context API를 통해 두 컴포넌트(header,Content) 에서 사용해야 하는데, 
`name` 이라는 값 하나때문에 Context의 타입을 지정하고, hook을 만들고 등등을 한다는 점이 좀 걸리네요...   사용하는 쪽에서 header와 content의 props에 동일한 값을 넣어주면 되긴 하는데 강제할 수는 없습니다
- InputBox를 보통 `Header / Content / Footer` 의 순서로 사용될 거 같은데, 이 순서를 강제할 필요가 있을까요?(사용하는 쪽에서 어떤 순서로 사용하던 children.type을 사용해서 Header를 무조건 첫번째로 오게 한다거나 이런게 가능하긴 합니다! )

- 현재 임시로 파일 구조를 만들긴 했는데, 사실 Header, content, footer는 재사용이 안되는 컴포넌트 이다보니 `export` 로 내보내고 싶지 않은데(자동완성에서도 걸리고) 그러면 한 파일 안에 모든 컴포넌트를 다 작성해야 하는데 그러면 가독성 측면에서 좀 별로일 것 같아서 일단 모든 컴포넌트를 다른 파일로 만들었습니다.
- 현재 header는 children으로 원하는 컴포넌트 삽입 가능, Content는 Input 컴포넌트로 고정해서 props로 전달, footer는 size와 color 고정으로 text string만 전달 가능하게 해놨는데, 관련해서 피드백 주시면 감사하겠습니다
### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
