### PR TITLE
 [feature/#392/ErrorMessage] ErrorMessage 컴포넌트

### DIFF
--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -3,6 +3,11 @@ import { FieldErrors, get, useFormContext } from "react-hook-form"
 
 import { ErrorMessageProps } from "./types/ErrorMessageProps"
 
+/**
+ * @errors {FieldErrors} useForm or useFormState에서 리턴된 errors 객체
+ * @name {string} register의 name에 해당하는 문자열
+ * @render {({message}) => JSX.Element} register의 message로 설정해놓은 값을 props로 가진 새로운 엘리먼트 리턴
+ */
 const ErrorMessage = <
   TFieldErrors extends FieldErrors,
   TAs extends
@@ -24,7 +29,7 @@ const ErrorMessage = <
     return null
   }
 
-  const { message: messageFromRegister } = error
+  const { message: messageFromRegister, types } = error
   const props = Object.assign({}, rest, {
     children: messageFromRegister || message,
   })
@@ -34,6 +39,7 @@ const ErrorMessage = <
     : render &&
         (render({
           message: messageFromRegister || message,
+          messages: types,
         }) as React.ReactElement)
 }
 

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,40 @@
+import React, { cloneElement, isValidElement } from "react"
+import { FieldErrors, get, useFormContext } from "react-hook-form"
+
+import { ErrorMessageProps } from "./types/ErrorMessageProps"
+
+const ErrorMessage = <
+  TFieldErrors extends FieldErrors,
+  TAs extends
+    | undefined
+    | React.ReactElement
+    | keyof JSX.IntrinsicElements = undefined,
+>({
+  as,
+  errors,
+  name,
+  message,
+  render,
+  ...rest
+}: ErrorMessageProps<TFieldErrors, TAs>) => {
+  const methods = useFormContext()
+  const error = get(errors || methods.formState.errors, name)
+
+  if (!error) {
+    return null
+  }
+
+  const { message: messageFromRegister } = error
+  const props = Object.assign({}, rest, {
+    children: messageFromRegister || message,
+  })
+
+  return isValidElement(as)
+    ? cloneElement(as, props)
+    : render &&
+        (render({
+          message: messageFromRegister || message,
+        }) as React.ReactElement)
+}
+
+export { ErrorMessage }

--- a/src/components/ErrorMessage/types/ErrorMessageProps.ts
+++ b/src/components/ErrorMessage/types/ErrorMessageProps.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import React from "react"
+import { FieldErrors, FieldName, Message } from "react-hook-form"
+
+type Assign<T extends object, U extends object> = T & Omit<U, keyof T>
+
+export type FieldValuesFromFieldErrors<TFieldErrors> =
+  TFieldErrors extends FieldErrors<infer TFieldValues> ? TFieldValues : never
+
+type AsProps<TAs> = TAs extends undefined
+  ? {}
+  : TAs extends React.ReactElement
+    ? Record<string, string>
+    : TAs extends React.ComponentType<infer P>
+      ? Omit<P, "children">
+      : TAs extends keyof JSX.IntrinsicElements
+        ? JSX.IntrinsicElements[TAs]
+        : never
+
+export type ErrorMessageProps<
+  TFieldErrors extends FieldErrors,
+  TAs extends undefined | React.ReactElement | keyof JSX.IntrinsicElements,
+> = Assign<
+  {
+    as?: TAs
+    errors: TFieldErrors
+    name: FieldName<FieldValuesFromFieldErrors<TFieldErrors>>
+    message?: Message
+    render?: (data: { message: Message }) => React.ReactNode
+  },
+  AsProps<TAs>
+>

--- a/src/components/ErrorMessage/types/ErrorMessageProps.ts
+++ b/src/components/ErrorMessage/types/ErrorMessageProps.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import React from "react"
-import { FieldErrors, FieldName, Message } from "react-hook-form"
+import {
+  FieldErrors,
+  FieldName,
+  Message,
+  MultipleFieldErrors,
+} from "react-hook-form"
 
 type Assign<T extends object, U extends object> = T & Omit<U, keyof T>
 
@@ -26,7 +31,10 @@ export type ErrorMessageProps<
     errors: TFieldErrors
     name: FieldName<FieldValuesFromFieldErrors<TFieldErrors>>
     message?: Message
-    render?: (data: { message: Message }) => React.ReactNode
+    render?: (data: {
+      message: Message
+      messages?: MultipleFieldErrors
+    }) => React.ReactNode
   },
   AsProps<TAs>
 >


### PR DESCRIPTION
## #️⃣연관된 이슈
close #92 
<!-- #이슈번호, #이슈번호-->

## 💡 핵심적으로 구현된 사항
-`@hookform/error-message` 라이브러리에서 제공하는 `ErrorMessage` 컴포넌트와 유사하게 구현하였습니다


기존 사용법
```typescript
  {errors['a'] && <Text>{errors['a']?.message}</Text>}
```

```typescript
const {
    register,
    handleSubmit,
    formState: { errors },
  } = useForm<{ a: string }>({ defaultValues: { a: "" } })
  console.log(errors)
  return (
    <>
      <form onSubmit={handleSubmit(() => console.log("a"))}>
        <Input {...register("a", { required: "필수" })}></Input>
        <ErrorMessage
          errors={errors}
          name="a"
          render={({ message }) => <Text>{message}</Text>}></ErrorMessage>
      </form>
    </>
  )
```



