### PR TITLE
[hotfix/#102/UserInfo] 유저 정보 저장 로직 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,11 @@ const queryClient = new QueryClient({
       gcTime: 1000 * 60 * 3,
       staleTime: 1000 * 60,
       refetchOnWindowFocus: false,
+      retry: 0,
     },
     mutations: {
       gcTime: 1000 * 60 * 3,
+      retry: 0,
     },
   },
 })

--- a/src/api/auth/postEmailAuth.ts
+++ b/src/api/auth/postEmailAuth.ts
@@ -1,12 +1,12 @@
-import { getEmailAuthResponseType } from "api-models"
+import { postEmailAuthResponseType } from "api-models"
 
 import { ENDPOINTS } from "@constants/endPoints"
 
 import { authInstance } from "../axiosInstance"
 
-export const getEmailAuth = async () => {
+export const postEmailAuth = async () => {
   //TODO: accessToken을 소셜 로그인과 이메일 로그인으로 분리하기위해 접두어로 'email', 'github' 등을 붙여야해서 slice로 잘라내는 작업 필요
-  const { data } = await authInstance.get<getEmailAuthResponseType>(
+  const { data } = await authInstance.post<postEmailAuthResponseType>(
     ENDPOINTS.EMAIL_AUTH,
   )
 

--- a/src/api/auth/postEmailRefresh.ts
+++ b/src/api/auth/postEmailRefresh.ts
@@ -2,23 +2,18 @@ import {
   postEmailRefreshPayload,
   postEmailRefreshResponseType,
 } from "api-models"
-import { AxiosRequestConfig } from "axios"
 
 import { ENDPOINTS } from "@constants/endPoints"
 
 import { baseInstance } from "../axiosInstance"
 
-export const postEmailRefresh = async (
-  { refreshToken }: postEmailRefreshPayload,
-  config: AxiosRequestConfig = {},
-) => {
-  const {
-    data: { accessToken },
-  } = await baseInstance.post<postEmailRefreshResponseType>(
+export const postEmailRefresh = async ({
+  refreshToken,
+}: postEmailRefreshPayload) => {
+  const { data } = await baseInstance.post<postEmailRefreshResponseType>(
     ENDPOINTS.EMAIL_REFRESH,
-    {},
-    { ...config, headers: { Authorization: `Bearer ${refreshToken}` } },
+    { refreshToken },
   )
 
-  return accessToken
+  return data
 }

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,4 +1,4 @@
-import axios, { isAxiosError } from "axios"
+import axios, { AxiosError, isAxiosError } from "axios"
 
 import authToken from "@stores/authToken"
 
@@ -15,18 +15,21 @@ export const authInstance = axios.create({
 //TODO: 소셜 로그인 로직 추가 예정
 authInstance.interceptors.request.use(
   async (config) => {
-    // const accessToken = authToken.getAccessToken()
-    // const refreshToken = authToken.getRefreshToken()
+    const accessToken = authToken.getAccessToken()
+    const refreshToken = authToken.getRefreshToken()
 
-    // if (!refreshToken) {
-    //   throw new AxiosError("Login Required")
-    // }
+    if (!refreshToken) {
+      throw new AxiosError("Login Required")
+    }
 
-    // if (!accessToken) {
-    //   const currentAccessToken = await postEmailRefresh({ refreshToken })
-    //   authToken.setAccessToken(currentAccessToken)
-    //   config.headers.Authorization = `Bearer ${currentAccessToken}`
-    // }
+    if (!accessToken) {
+      const currentAccessToken = await postEmailRefresh({ refreshToken })
+      authToken.setAccessToken(currentAccessToken)
+      config.headers.Authorization = `Bearer ${currentAccessToken}`
+    }
+
+    config.headers.Authorization = `Bearer ${accessToken}`
+
     return config
   },
   (error) => {

--- a/src/constants/customError.ts
+++ b/src/constants/customError.ts
@@ -1,0 +1,9 @@
+export class LogoutError extends Error {
+  name = "Logout"
+  message = "로그아웃 처리됩니다."
+}
+
+export class PermissionError extends Error {
+  name = "PermissionError"
+  message = "권한이 없습니다."
+}

--- a/src/constants/endPoints.ts
+++ b/src/constants/endPoints.ts
@@ -3,8 +3,8 @@ const VARIABLE_URL = "/api/v1"
 export const ENDPOINTS = {
   GITHUB_LOGIN: `${VARIABLE_URL}/auth/login/github`,
   EMAIL_LOGIN: `${VARIABLE_URL}/auth/login`,
-  EMAIL_REFRESH: `${VARIABLE_URL}/auth/refresh`,
-  EMAIL_AUTH: `${VARIABLE_URL}/auth/login/me`,
+  EMAIL_REFRESH: `${VARIABLE_URL}/auth/reissue`,
+  EMAIL_AUTH: `${VARIABLE_URL}/auth/me`,
   EMAIL_SIGNUP: `${VARIABLE_URL}/users/signup`,
   GET_USER_NICKNAME: `${VARIABLE_URL}/users?keyword=`,
   GET_USER_PROFILE: (userId: number) => `${VARIABLE_URL}/users/${userId}`,

--- a/src/mocks/auth/postEmailAuth.mock.ts
+++ b/src/mocks/auth/postEmailAuth.mock.ts
@@ -1,10 +1,10 @@
-import { getEmailAuthResponseType } from "api-models"
+import { postEmailAuthResponseType } from "api-models"
 import { rest } from "msw"
 
 import { ENDPOINTS } from "@constants/endPoints"
 
-export const getEmailAuth = rest.get(ENDPOINTS.EMAIL_AUTH, (_, res, ctx) => {
-  const response: getEmailAuthResponseType = {
+export const postEmailAuth = rest.post(ENDPOINTS.EMAIL_AUTH, (_, res, ctx) => {
+  const response: postEmailAuthResponseType = {
     id: 1,
     nickname: "admin",
     profileImageUrl: null,

--- a/src/mocks/auth/postEmailRefresh.mock.ts
+++ b/src/mocks/auth/postEmailRefresh.mock.ts
@@ -8,6 +8,12 @@ export const postEmailRefresh = rest.post(
   (_, res, ctx) => {
     const response: postEmailRefreshResponseType = {
       accessToken: "mock-accessToken",
+      refreshToken: "mock-refreshToken",
+      user: {
+        id: 0,
+        nickname: "admin",
+        profileImageUrl: null,
+      },
     }
     return res(ctx.status(200), ctx.json(response))
   },

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,7 +4,7 @@ import allProjectHandlers from "@pages/HomePage/mocks"
 import { projectsHandlers, userInfoHandlers } from "@pages/ProfilePage/mocks"
 import { projectDetailHandlers } from "@pages/ProjectDetailPage/mocks"
 
-import { getEmailAuth } from "./auth/getEmailAuth.mock"
+import { postEmailAuth } from "./auth/postEmailAuth.mock"
 import { postEmailLogin } from "./auth/postEmailLogin.mock"
 import { postEmailRefresh } from "./auth/postEmailRefresh.mock"
 
@@ -14,7 +14,7 @@ export const handlers = [
   ...allProjectHandlers,
   postEmailRefresh,
   postEmailLogin,
-  getEmailAuth,
+  postEmailAuth,
   ...userInfoHandlers,
   ...projectsHandlers,
 ]

--- a/src/services/caches/useUserInfoData.ts
+++ b/src/services/caches/useUserInfoData.ts
@@ -1,11 +1,11 @@
-import { useQuery } from "@tanstack/react-query"
+import { postEmailAuth } from "@api/auth/postEmailAuth"
 
-import { getEmailAuth } from "@/api/auth/getEmailAuth"
+import { useQuery } from "@tanstack/react-query"
 
 import { QUERYKEY } from "@constants/queryKey"
 
 export const useUserInfoData = () => {
-  return useQuery<Awaited<ReturnType<typeof getEmailAuth>>>({
+  return useQuery<Awaited<ReturnType<typeof postEmailAuth>>>({
     queryKey: [QUERYKEY.USER_INFO],
   }).data
 }

--- a/src/services/queries/userInfoOptions.ts
+++ b/src/services/queries/userInfoOptions.ts
@@ -1,12 +1,12 @@
-import { UseQueryOptions } from "@tanstack/react-query"
+import { postEmailAuth } from "@api/auth/postEmailAuth"
 
-import { getEmailAuth } from "@/api/auth/getEmailAuth"
+import { UseQueryOptions } from "@tanstack/react-query"
 
 import { QUERYKEY } from "@constants/queryKey"
 
 export const userInfoOptions: UseQueryOptions<
-  Awaited<ReturnType<typeof getEmailAuth>>
+  Awaited<ReturnType<typeof postEmailAuth>>
 > = {
   queryKey: [QUERYKEY.USER_INFO],
-  queryFn: getEmailAuth,
+  queryFn: () => postEmailAuth(),
 }

--- a/src/stores/authToken.ts
+++ b/src/stores/authToken.ts
@@ -8,8 +8,10 @@ class AuthToken {
   private REFRESH_KEY: string
 
   constructor() {
-    this.accessToken = ""
-    this.refreshToken = ""
+    this.accessToken =
+      localStorage.getItem(VITE_AUTH_JWT_TOKEN_STORAGE_KEY) ?? ""
+    this.refreshToken =
+      localStorage.getItem(VITE_REFRESH_JWT_TOKEN_STORAGE_KEY) ?? ""
     this.ACCESS_KEY = VITE_AUTH_JWT_TOKEN_STORAGE_KEY
     this.REFRESH_KEY = VITE_REFRESH_JWT_TOKEN_STORAGE_KEY
   }

--- a/src/types/domain/apiDomain.d.ts
+++ b/src/types/domain/apiDomain.d.ts
@@ -164,7 +164,7 @@ declare module "api-models" {
   }
 
   /* 인증 관련 */
-  export type getEmailAuthResponseType = UserSummary
+  export type postEmailAuthResponseType = UserSummary
 
   export type postEmailRefreshPayload = {
     refreshToken: string

--- a/src/types/domain/apiDomain.d.ts
+++ b/src/types/domain/apiDomain.d.ts
@@ -172,6 +172,8 @@ declare module "api-models" {
 
   export type postEmailRefreshResponseType = {
     accessToken: string
+    refreshToken: string
+    user: UserSummary
   }
 
   export type postEmailLoginPayload = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,15 @@ import tsconfigPaths from "vite-tsconfig-paths"
 export default defineConfig(({ command }) => ({
   plugins: [react(), tsconfigPaths(), splitVendorChunkPlugin()],
   publicDir: command === "serve" ? "public" : false,
+  server: {
+    proxy: {
+      "/serve": {
+        target: "http://3.39.156.144:8080",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/serve/, ""),
+      },
+    },
+  },
   build: {
     chunkSizeWarningLimit: 1600,
     rollupOptions: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,15 +6,6 @@ import tsconfigPaths from "vite-tsconfig-paths"
 export default defineConfig(({ command }) => ({
   plugins: [react(), tsconfigPaths(), splitVendorChunkPlugin()],
   publicDir: command === "serve" ? "public" : false,
-  server: {
-    proxy: {
-      "/serve": {
-        target: "http://3.39.156.144:8080",
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/serve/, ""),
-      },
-    },
-  },
   build: {
     chunkSizeWarningLimit: 1600,
     rollupOptions: {


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->
close #102 

## 💡 핵심적으로 구현된 사항

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->
- 토큰이 정상적으로 Authorization에 들어가지 않던 문제를 수정하였습니다.
- 엔드포인트 변경에 의한 url 변경하였습니다.
- authToken에서 초기값으로 토큰이 아닌 공백문자를 저장하던 문제를 수정하였습니다.

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 커스텀 에러를 통해 에러 핸들링을 구현하였습니다.

## ▶️ 테스트,검증

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- 엔드포인트나 응답값 변경으로 수정된 부분들을 제외한 `authToken` 로직과 `axiosInstance` 부분을 봐주시면 됩니다!

## 🤔 고민 사항
- 그리고 `customError`로 에러 바운더리에서 해당 에러가 커스텀에러의 인스턴스인지 판단하여 에러 핸들링하려 합니다! 혹시 더 좋은 아이디어나 참고할만한 레퍼런스가 있으면 공유 부탁드립니다~!
- 중복 코드는 나중에 리팩토링 하겠습니다 ㅎㅎ;;;

## `vite.config.ts` 가 수정되어 이제 기본적으로 서버로 api 요청을 보냅니다!!

- 혹시 msw로 전환하고 싶으신분은 baseUrl을 공백으로 바꾸시면 됩니다~
- 더 자세한건 노션 - 프론트엔드 - 논의사항을 참고해주세요!