### PR TITLE
[refactor/#100/ProfilePage] 프로필 페이지 - 프로필 바 api 반영

### DIFF
--- a/src/api/user/getUserDetail.ts
+++ b/src/api/user/getUserDetail.ts
@@ -11,7 +11,9 @@ export const getUserDetail = async (
 ) => {
   const { data } = await baseInstance.get<getUserDetailResponseType>(
     ENDPOINTS.GET_USER_PROFILE(userId),
-    { ...config },
+    {
+      ...config,
+    },
   )
 
   return data

--- a/src/api/user/getUserDetail.ts
+++ b/src/api/user/getUserDetail.ts
@@ -1,19 +1,12 @@
 import { getUserDetailPayload, getUserDetailResponseType } from "api-models"
-import { AxiosRequestConfig } from "axios"
 
 import { ENDPOINTS } from "@constants/endPoints"
 
 import { baseInstance } from "../axiosInstance"
 
-export const getUserDetail = async (
-  { userId }: getUserDetailPayload,
-  config: AxiosRequestConfig = {},
-) => {
+export const getUserDetail = async ({ userId }: getUserDetailPayload) => {
   const { data } = await baseInstance.get<getUserDetailResponseType>(
     ENDPOINTS.GET_USER_PROFILE(userId),
-    {
-      ...config,
-    },
   )
 
   return data

--- a/src/pages/ProfilePage/LargeScreenView/LargeScreen.view.tsx
+++ b/src/pages/ProfilePage/LargeScreenView/LargeScreen.view.tsx
@@ -8,10 +8,10 @@ import { ProfileActionsButtonsProps } from "../types/types"
 export interface ProfileBarProps extends ProfileActionsButtonsProps {
   nickname: string
   profileImageUrl: string
-  career: string
-  introduction: string
-  githubUrl: string
-  blogUrl: string
+  career: string | null
+  introduction: string | null
+  githubUrl: string | null
+  blogUrl: string | null
   techStacks: TechStack[]
 }
 

--- a/src/pages/ProfilePage/SmallScreenView/SmallScreen.view.tsx
+++ b/src/pages/ProfilePage/SmallScreenView/SmallScreen.view.tsx
@@ -7,7 +7,7 @@ import { ProfileActionsButtonsProps } from "../types/types"
 interface ProfileCardProps extends ProfileActionsButtonsProps {
   profileImageUrl?: string
   nickname?: string
-  career?: string
+  career?: string | null
 }
 const SmallScreenView = ({
   nickname,

--- a/src/pages/ProfilePage/components/HOC/withUserId.tsx
+++ b/src/pages/ProfilePage/components/HOC/withUserId.tsx
@@ -1,11 +1,11 @@
 import { ComponentType } from "react"
 import { useParams } from "react-router-dom"
 
-interface UserIdProps {
+export interface UserIdProps {
   userId: string
 }
 const withUserId = <P extends UserIdProps>(
-  WrappeedComponent: ComponentType<P>,
+  WrappedComponent: ComponentType<P>,
 ) => {
   const ComponentWithUserId = (props: Omit<P, keyof UserIdProps>) => {
     const { userId } = useParams()
@@ -14,7 +14,7 @@ const withUserId = <P extends UserIdProps>(
       return null
     }
     return (
-      <WrappeedComponent
+      <WrappedComponent
         {...(props as P)}
         userId={userId}
       />

--- a/src/pages/ProfilePage/components/HOC/withUserId.tsx
+++ b/src/pages/ProfilePage/components/HOC/withUserId.tsx
@@ -1,0 +1,26 @@
+import { ComponentType } from "react"
+import { useParams } from "react-router-dom"
+
+interface UserIdProps {
+  userId: string
+}
+const withUserId = <P extends UserIdProps>(
+  WrappeedComponent: ComponentType<P>,
+) => {
+  const ComponentWithUserId = (props: Omit<P, keyof UserIdProps>) => {
+    const { userId } = useParams()
+
+    if (!userId) {
+      return null
+    }
+    return (
+      <WrappeedComponent
+        {...(props as P)}
+        userId={userId}
+      />
+    )
+  }
+  return ComponentWithUserId
+}
+
+export default withUserId

--- a/src/pages/ProfilePage/components/Profile/Profile.controller.tsx
+++ b/src/pages/ProfilePage/components/Profile/Profile.controller.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
 
 import { Box, Flex, useMediaQuery } from "@chakra-ui/react"
 
@@ -10,7 +10,9 @@ import { useUserInfo } from "./Profile.model"
 const ProfileController = () => {
   const [isLargerThan1200] = useMediaQuery("(min-width: 1200px)")
 
-  const { data } = useUserInfo({ userId: 1 })
+  const { userId } = useParams()
+
+  const { data } = useUserInfo({ userId: Number(userId) })
 
   const navigate = useNavigate()
   const handleNewProject = () => {
@@ -39,7 +41,7 @@ const ProfileController = () => {
     githubUrl,
     blogUrl,
     techStacks,
-  } = data.userInfo
+  } = data
 
   return (
     <Box>

--- a/src/pages/ProfilePage/components/Profile/Profile.controller.tsx
+++ b/src/pages/ProfilePage/components/Profile/Profile.controller.tsx
@@ -1,16 +1,15 @@
-import { useNavigate, useParams } from "react-router-dom"
+import { useNavigate } from "react-router-dom"
 
 import { Box, Flex, useMediaQuery } from "@chakra-ui/react"
 
 import LargeScreenView from "@pages/ProfilePage/LargeScreenView/LargeScreen.view"
 import SmallScreenView from "@pages/ProfilePage/SmallScreenView/SmallScreen.view"
 
+import withUserId, { UserIdProps } from "../HOC/withUserId"
 import { useUserInfo } from "./Profile.model"
 
-const ProfileController = () => {
+const ProfileController = ({ userId }: UserIdProps) => {
   const [isLargerThan1200] = useMediaQuery("(min-width: 1200px)")
-
-  const { userId } = useParams()
 
   const { data } = useUserInfo({ userId: Number(userId) })
 
@@ -83,4 +82,4 @@ const ProfileController = () => {
   )
 }
 
-export default ProfileController
+export default withUserId(ProfileController)

--- a/src/pages/ProfilePage/components/Profile/ProfileBar.view.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileBar.view.tsx
@@ -12,13 +12,13 @@ import ProfileTechStack from "./ProfileTechStack"
 
 // TODO: props 타입이 undefined가 될수 있다는게 뭔가 이상함 이렇게 안하면 케찹 터짐. 해결해보기
 export interface ProfileBarProps extends ProfileActionsButtonsProps {
-  nickname: string | undefined
-  profileImageUrl: string | undefined
-  career: string | undefined
-  introduction: string | undefined
-  githubUrl: string | undefined
-  blogUrl: string | undefined
-  techStacks: TechStack[] | undefined
+  nickname: string
+  profileImageUrl: string
+  career: string | null
+  introduction: string | null
+  githubUrl: string | null
+  blogUrl: string | null
+  techStacks: TechStack[]
 }
 
 const ProfileBarView = ({

--- a/src/pages/ProfilePage/components/Profile/ProfileCard.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileCard.tsx
@@ -29,11 +29,13 @@ const ProfileCard = ({
         fontFamily="SCDream_Bold">
         {nickname}
       </Text>
-      <Text
-        mt="-3"
-        fontSize="2xl">
-        {career} 개발자
-      </Text>
+      {career && (
+        <Text
+          mt="-3"
+          fontSize="2xl">
+          {career} 개발자
+        </Text>
+      )}
       <ProfileActionsButtons {...{ handleNewProject, handleEditProfile }} />
     </VStack>
   )

--- a/src/pages/ProfilePage/components/Profile/ProfileCard.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileCard.tsx
@@ -7,7 +7,7 @@ import ProfileActionsButtons from "./ProfileActionsButtons"
 interface ProfileCardProps extends ProfileActionsButtonsProps {
   profileImageUrl?: string
   nickname?: string
-  career?: string
+  career?: string | null
 }
 
 const ProfileCard = ({

--- a/src/pages/ProfilePage/components/Profile/ProfileIntroduction.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileIntroduction.tsx
@@ -33,23 +33,34 @@ const ProfileIntroduction = ({
 
       <HStack mt="1.5rem">
         <ImGithub size="2.6rem" />
-
-        {githubUrl && (
+        {githubUrl ? (
           <Link
             href={githubUrl}
             fontSize="1.3rem">
-            GitHub 링크
+            {githubUrl}
           </Link>
+        ) : (
+          <Text
+            fontSize="1.3rem"
+            mt="0.5rem">
+            Github 링크가 없습니다
+          </Text>
         )}
       </HStack>
       <HStack mt="0.8rem">
         <FaSquarePen size="2.6rem" />
-        {blogUrl && (
+        {blogUrl ? (
           <Link
             href={blogUrl}
             fontSize="1.3rem">
-            Blog 링크
+            {blogUrl}
           </Link>
+        ) : (
+          <Text
+            fontSize="1.3rem"
+            mt="0.3rem">
+            Blog 링크가 없습니다
+          </Text>
         )}
       </HStack>
     </Box>

--- a/src/pages/ProfilePage/components/Profile/ProfileIntroduction.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileIntroduction.tsx
@@ -1,7 +1,6 @@
-import { FaSquarePen } from "react-icons/fa6"
-import { ImGithub } from "react-icons/im"
+import { Box, Text } from "@chakra-ui/react"
 
-import { Box, HStack, Link, Text } from "@chakra-ui/react"
+import ProfileLink from "./ProfileLink"
 
 // TODO: props 타입이 undefined가 될수 있다는게 뭔가 이상함 이렇게 안하면 케찹 터짐. 해결해보기
 interface IntroductionProps {
@@ -30,41 +29,10 @@ const ProfileIntroduction = ({
         fontSize="md">
         {aboutMe}
       </Text>
-
-      <HStack mt="1.5rem">
-        <ImGithub size="2.6rem" />
-        {githubUrl ? (
-          <Link
-            href={githubUrl}
-            fontSize="1.3rem">
-            {githubUrl}
-          </Link>
-        ) : (
-          <Text
-            fontSize="1.3rem"
-            color="grey.500"
-            mt="0.5rem">
-            Github 링크가 없습니다
-          </Text>
-        )}
-      </HStack>
-      <HStack mt="0.8rem">
-        <FaSquarePen size="2.6rem" />
-        {blogUrl ? (
-          <Link
-            href={blogUrl}
-            fontSize="1.3rem">
-            {blogUrl}
-          </Link>
-        ) : (
-          <Text
-            fontSize="1.3rem"
-            color="grey.500"
-            mt="0.3rem">
-            Blog 링크가 없습니다
-          </Text>
-        )}
-      </HStack>
+      <ProfileLink
+        githubUrl={githubUrl}
+        blogUrl={blogUrl}
+      />
     </Box>
   )
 }

--- a/src/pages/ProfilePage/components/Profile/ProfileIntroduction.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileIntroduction.tsx
@@ -5,9 +5,9 @@ import { Box, HStack, Link, Text } from "@chakra-ui/react"
 
 // TODO: props 타입이 undefined가 될수 있다는게 뭔가 이상함 이렇게 안하면 케찹 터짐. 해결해보기
 interface IntroductionProps {
-  aboutMe: string | undefined
-  githubUrl: string | undefined
-  blogUrl: string | undefined
+  aboutMe?: string | null
+  githubUrl?: string | null
+  blogUrl?: string | null
 }
 
 const ProfileIntroduction = ({
@@ -34,19 +34,23 @@ const ProfileIntroduction = ({
       <HStack mt="1.5rem">
         <ImGithub size="2.6rem" />
 
-        <Link
-          href={githubUrl}
-          fontSize="1.3rem">
-          GitHub 링크
-        </Link>
+        {githubUrl && (
+          <Link
+            href={githubUrl}
+            fontSize="1.3rem">
+            GitHub 링크
+          </Link>
+        )}
       </HStack>
       <HStack mt="0.8rem">
         <FaSquarePen size="2.6rem" />
-        <Link
-          href={blogUrl}
-          fontSize="1.3rem">
-          Blog 링크
-        </Link>
+        {blogUrl && (
+          <Link
+            href={blogUrl}
+            fontSize="1.3rem">
+            Blog 링크
+          </Link>
+        )}
       </HStack>
     </Box>
   )

--- a/src/pages/ProfilePage/components/Profile/ProfileIntroduction.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileIntroduction.tsx
@@ -42,6 +42,7 @@ const ProfileIntroduction = ({
         ) : (
           <Text
             fontSize="1.3rem"
+            color="grey.500"
             mt="0.5rem">
             Github 링크가 없습니다
           </Text>
@@ -58,6 +59,7 @@ const ProfileIntroduction = ({
         ) : (
           <Text
             fontSize="1.3rem"
+            color="grey.500"
             mt="0.3rem">
             Blog 링크가 없습니다
           </Text>

--- a/src/pages/ProfilePage/components/Profile/ProfileIntroduction.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileIntroduction.tsx
@@ -1,4 +1,7 @@
-import { Box, Text } from "@chakra-ui/react"
+import { FaSquarePen } from "react-icons/fa6"
+import { ImGithub } from "react-icons/im"
+
+import { Box, Flex, Text } from "@chakra-ui/react"
 
 import ProfileLink from "./ProfileLink"
 
@@ -29,10 +32,20 @@ const ProfileIntroduction = ({
         fontSize="md">
         {aboutMe}
       </Text>
-      <ProfileLink
-        githubUrl={githubUrl}
-        blogUrl={blogUrl}
-      />
+      <Flex
+        direction="column"
+        gap="0.7rem">
+        <ProfileLink
+          Icon={ImGithub}
+          url={githubUrl}
+          alt="Github"
+        />
+        <ProfileLink
+          Icon={FaSquarePen}
+          url={blogUrl}
+          alt="Blog"
+        />
+      </Flex>
     </Box>
   )
 }

--- a/src/pages/ProfilePage/components/Profile/ProfileLink.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileLink.tsx
@@ -1,0 +1,52 @@
+import { FaSquarePen } from "react-icons/fa6"
+import { ImGithub } from "react-icons/im"
+
+import { HStack, Link, Text } from "@chakra-ui/react"
+
+interface ProfileLinkProps {
+  githubUrl?: string | null
+  blogUrl?: string | null
+}
+
+const ProfileLink = ({ githubUrl, blogUrl }: ProfileLinkProps) => {
+  return (
+    <>
+      <HStack mt="1.5rem">
+        <ImGithub size="2.6rem" />
+        {githubUrl ? (
+          <Link
+            href={githubUrl}
+            fontSize="1.3rem">
+            {githubUrl}
+          </Link>
+        ) : (
+          <Text
+            fontSize="1.3rem"
+            color="grey.500"
+            mt="0.5rem">
+            Github 링크가 없습니다
+          </Text>
+        )}
+      </HStack>
+      <HStack mt="0.8rem">
+        <FaSquarePen size="2.6rem" />
+        {blogUrl ? (
+          <Link
+            href={blogUrl}
+            fontSize="1.3rem">
+            {blogUrl}
+          </Link>
+        ) : (
+          <Text
+            fontSize="1.3rem"
+            color="grey.500"
+            mt="0.3rem">
+            Blog 링크가 없습니다
+          </Text>
+        )}
+      </HStack>
+    </>
+  )
+}
+
+export default ProfileLink

--- a/src/pages/ProfilePage/components/Profile/ProfileLink.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileLink.tsx
@@ -1,51 +1,32 @@
-import { FaSquarePen } from "react-icons/fa6"
-import { ImGithub } from "react-icons/im"
+import { FunctionComponent } from "react"
 
 import { HStack, Link, Text } from "@chakra-ui/react"
 
 interface ProfileLinkProps {
-  githubUrl?: string | null
-  blogUrl?: string | null
+  Icon: FunctionComponent<{ size: string }>
+  url?: string | null
+  alt: string
 }
 
-const ProfileLink = ({ githubUrl, blogUrl }: ProfileLinkProps) => {
+const ProfileLink = ({ Icon, url, alt }: ProfileLinkProps) => {
   return (
-    <>
-      <HStack mt="1.5rem">
-        <ImGithub size="2.6rem" />
-        {githubUrl ? (
-          <Link
-            href={githubUrl}
-            fontSize="1.3rem">
-            {githubUrl}
-          </Link>
-        ) : (
-          <Text
-            fontSize="1.3rem"
-            color="grey.500"
-            mt="0.5rem">
-            Github 링크가 없습니다
-          </Text>
-        )}
-      </HStack>
-      <HStack mt="0.8rem">
-        <FaSquarePen size="2.6rem" />
-        {blogUrl ? (
-          <Link
-            href={blogUrl}
-            fontSize="1.3rem">
-            {blogUrl}
-          </Link>
-        ) : (
-          <Text
-            fontSize="1.3rem"
-            color="grey.500"
-            mt="0.3rem">
-            Blog 링크가 없습니다
-          </Text>
-        )}
-      </HStack>
-    </>
+    <HStack>
+      <Icon size="2.6rem" />
+      {url ? (
+        <Link
+          href={url}
+          fontSize="1.3rem">
+          {url}
+        </Link>
+      ) : (
+        <Text
+          fontSize="1.3rem"
+          color="grey.500"
+          mt="0.5rem">
+          {alt} 링크가 없습니다.
+        </Text>
+      )}
+    </HStack>
   )
 }
 

--- a/src/pages/ProfilePage/components/Profile/ProfileTechStack.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileTechStack.tsx
@@ -5,7 +5,7 @@ import ProfileTechStackByCategory from "./ProfileTechStackByCategory"
 
 // TODO: props 타입이 undefined가 될수 있다는게 뭔가 이상함 이렇게 안하면 케찹 터짐. 해결해보기
 interface TechStackProps {
-  techStacks: TechStack[] | undefined
+  techStacks?: TechStack[]
 }
 
 const ProfileTechStack = ({ techStacks }: TechStackProps) => {

--- a/src/pages/ProfilePage/components/Profile/ProfileTechStack.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileTechStack.tsx
@@ -23,13 +23,23 @@ const ProfileTechStack = ({ techStacks }: TechStackProps) => {
         fontFamily="SCDream_Bold">
         기술스택
       </Text>
-      {categories.map((category) => (
-        <ProfileTechStackByCategory
-          key={category}
-          category={category}
-          techStacks={techStacks}
-        />
-      ))}
+
+      {categories.length !== 0 ? (
+        categories.map((category) => (
+          <ProfileTechStackByCategory
+            key={category}
+            category={category}
+            techStacks={techStacks}
+          />
+        ))
+      ) : (
+        <Text
+          fontSize="1.3rem"
+          color="grey.500"
+          mt="1rem">
+          등록된 기술스택이 없습니다
+        </Text>
+      )}
     </Box>
   )
 }

--- a/src/pages/ProfilePage/components/Profile/ProfileTechStackByCategory.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileTechStackByCategory.tsx
@@ -6,7 +6,7 @@ import CommonTag from "@components/Tag/components/CommonTag"
 // TODO: props 타입이 undefined가 될수 있다는게 뭔가 이상함 이렇게 안하면 케찹 터짐. 해결해보기
 interface ProfileTechStackByCategoryProps {
   category: string
-  techStacks: TechStack[]
+  techStacks?: TechStack[]
 }
 
 const ProfileTechStackByCategory = ({

--- a/src/pages/ProfilePage/components/Profile/ProfileTechStackByCategory.tsx
+++ b/src/pages/ProfilePage/components/Profile/ProfileTechStackByCategory.tsx
@@ -6,7 +6,7 @@ import CommonTag from "@components/Tag/components/CommonTag"
 // TODO: props 타입이 undefined가 될수 있다는게 뭔가 이상함 이렇게 안하면 케찹 터짐. 해결해보기
 interface ProfileTechStackByCategoryProps {
   category: string
-  techStacks: TechStack[] | undefined
+  techStacks: TechStack[]
 }
 
 const ProfileTechStackByCategory = ({

--- a/src/types/domain/apiDomain.d.ts
+++ b/src/types/domain/apiDomain.d.ts
@@ -20,12 +20,12 @@ declare module "api-models" {
 
   export type UserInfoProperties = {
     nickname: string
-    introduction: string
+    introduction: string | null
     profileImageUrl: string
-    job: string
-    career: string
-    githubUrl: string
-    blogUrl: string
+    job: string | null
+    career: string | null
+    githubUrl: string | null
+    blogUrl: string | null
     techStacks: TechStack[]
   }
   export interface UserInfo {
@@ -202,7 +202,7 @@ declare module "api-models" {
 
   export type getUserDetailPayload = { userId: number }
 
-  export type getUserDetailResponseType = UserInfo
+  export type getUserDetailResponseType = UserInfoProperties
 
   export type putUserDetailPayload = {
     userId: number

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,15 @@ import tsconfigPaths from "vite-tsconfig-paths"
 
 export default defineConfig(({ command }) => ({
   plugins: [react(), tsconfigPaths(), splitVendorChunkPlugin()],
+  server: {
+    proxy: {
+      "/serve": {
+        target: "http://3.39.156.144:8080",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/serve/, ""),
+      },
+    },
+  },
   publicDir: command === "serve" ? "public" : false,
   build: {
     chunkSizeWarningLimit: 1600,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,16 +5,15 @@ import tsconfigPaths from "vite-tsconfig-paths"
 
 export default defineConfig(({ command }) => ({
   plugins: [react(), tsconfigPaths(), splitVendorChunkPlugin()],
+  publicDir: command === "serve" ? "public" : false,
   server: {
     proxy: {
-      "/serve": {
+      "/api": {
         target: "http://3.39.156.144:8080",
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/serve/, ""),
       },
     },
   },
-  publicDir: command === "serve" ? "public" : false,
   build: {
     chunkSizeWarningLimit: 1600,
     rollupOptions: {


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->
close #100 

## 💡 핵심적으로 구현된 사항

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->
<img width="401" alt="스크린샷 2024-03-12 오전 12 44 14" src="https://github.com/side-peek/sidepeek_frontend/assets/124658938/48ee0d79-7958-40c3-bf0f-3636be96897f">

- 세부 디자인은 미완성 상태입니다.
- 프로필 페이지의 프로필 바 컴포넌트에 완성된 api를 붙였습니다.
- msw 사용 -> 완성된 api 사용을 위해 vite.config 파일을 수정했습니다.
- getUserDetail api 응답 타입을 수정했습니다.

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

- 지금 아래와 같이 받아온 데이터 안의 모든 필드를 다 사용합니다. 이 경우엔 useQuery의 select 옵션이 따로 필요없는 걸까요?  
```typescript
  const {
    nickname,
    profileImageUrl,
    career,
    introduction,
    githubUrl,
    blogUrl,
    techStacks,
  } = data
``` 
- 컴포넌트, 로직을 분리할 부분이 더 있다고 생각되면 의견 부탁드리겠습니다.

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
