### PR TITLE
[Feature/#101/postFile] 파일 업로드 관련 custom hook 추가

### DIFF
--- a/src/api/projectFile/postProjectFiles.ts
+++ b/src/api/projectFile/postProjectFiles.ts
@@ -1,20 +1,18 @@
-import {
-  postProjectFilesPayload,
-  postProjectFilesResponseType,
-} from "api-models"
-import { AxiosRequestConfig } from "axios"
+import { postProjectFilesResponseType } from "api-models"
 
 import { ENDPOINTS } from "@constants/endPoints"
 
 import { baseInstance } from "../axiosInstance"
 
-export const postProjectFiles = async (
-  { file }: postProjectFilesPayload,
-  config: AxiosRequestConfig = {},
-) => {
-  await baseInstance.post<postProjectFilesResponseType>(
+export const postProjectFiles = async (file: FormData) => {
+  const { data } = await baseInstance.post<postProjectFilesResponseType>(
     ENDPOINTS.UPLOAD_PROJECT_FILES,
     file,
-    { ...config },
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    },
   )
+  return data
 }

--- a/src/api/projectFile/postProjectFiles.ts
+++ b/src/api/projectFile/postProjectFiles.ts
@@ -1,10 +1,12 @@
 import { postProjectFilesResponseType } from "api-models"
 
+import { PostFormDataType } from "@pages/ProjectEditPage/types/PostFormDataType"
+
 import { ENDPOINTS } from "@constants/endPoints"
 
 import { baseInstance } from "../axiosInstance"
 
-export const postProjectFiles = async (file: FormData) => {
+export const postProjectFiles = async (file: PostFormDataType) => {
   const { data } = await baseInstance.post<postProjectFilesResponseType>(
     ENDPOINTS.UPLOAD_PROJECT_FILES,
     file,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,6 +3,7 @@ import { searchHandlers } from "@components/Search/mocks"
 import allProjectHandlers from "@pages/HomePage/mocks"
 import { projectsHandlers, userInfoHandlers } from "@pages/ProfilePage/mocks"
 import { projectDetailHandlers } from "@pages/ProjectDetailPage/mocks"
+import { projectEditHandler } from "@pages/ProjectEditPage/mocks"
 
 import { postEmailAuth } from "./auth/postEmailAuth.mock"
 import { postEmailLogin } from "./auth/postEmailLogin.mock"
@@ -17,4 +18,5 @@ export const handlers = [
   postEmailAuth,
   ...userInfoHandlers,
   ...projectsHandlers,
+  ...projectEditHandler,
 ]

--- a/src/pages/ProjectEditPage/hooks/useFileUpload.ts
+++ b/src/pages/ProjectEditPage/hooks/useFileUpload.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react"
+
+import { postProjectFiles } from "@api/projectFile/postProjectFiles"
+
+import { FileUploadStateType } from "../types/FileUploadStateType"
+
+export const useFileUpload = () => {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const [files, setFiles] = useState<
+    FileUploadStateType<{ fileUrl: string }>[]
+  >([])
+
+  const onChangeFile = async (e: Event, fileLength: number) => {
+    if (!(e.target as HTMLInputElement).files) return
+    const selectFiles = (e.target as HTMLInputElement).files as FileList
+    const uploadFiles = Array.from(selectFiles)
+
+    if (files.length + uploadFiles.length > 6) {
+      alert("더이상 추가할 수 없습니다")
+      return
+    }
+
+    const promises = Object.values(uploadFiles).map((file, idx) => {
+      const imageFormData = new FormData()
+      imageFormData.append("file", file)
+
+      const index = fileLength + idx - 1 < 0 ? 0 : fileLength + idx
+
+      setFiles((prev) => [
+        ...prev,
+        { isLoading: true, error: null, data: null },
+      ])
+
+      return postProjectFiles(imageFormData)
+        .then((data) => {
+          setFiles((prev) => {
+            console.log(index)
+
+            const updatedFiles = [...prev]
+            updatedFiles[index] = {
+              isLoading: false,
+              error: null,
+              data,
+            }
+            return updatedFiles
+          })
+        })
+        .catch((error) => {
+          // 실패 시 파일 상태 업데이트
+          setFiles((prev) => {
+            console.log(index)
+
+            const updatedFiles = [...prev]
+            updatedFiles[index] = {
+              isLoading: false,
+              error,
+              data: null,
+            }
+            return updatedFiles
+          })
+        })
+    })
+
+    await Promise.allSettled(promises)
+  }
+
+  useEffect(() => {
+    if (!inputRef.current) return
+    const { current } = inputRef
+    const currentlength = files.length
+
+    const handleFileChange = (e: Event) => {
+      onChangeFile(e, currentlength)
+    }
+    inputRef.current.setAttribute("type", "file")
+
+    inputRef.current.addEventListener("change", handleFileChange)
+    return () => {
+      current?.removeEventListener("change", handleFileChange)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputRef, files])
+
+  return {
+    inputRef,
+    files,
+  }
+}

--- a/src/pages/ProjectEditPage/hooks/usePostFileMutation.ts
+++ b/src/pages/ProjectEditPage/hooks/usePostFileMutation.ts
@@ -4,12 +4,19 @@ import { AxiosError } from "axios"
 
 import { UseMutationOptions, useMutation } from "@tanstack/react-query"
 
+import { PostFormDataType } from "../types/PostFormDataType"
+import { TypedFormData } from "../types/TypedFormDataValue"
+
 export const usePostFileMutation = ({
   ...options
-}: UseMutationOptions<postProjectFilesResponseType, AxiosError, FormData>) => {
+}: UseMutationOptions<
+  postProjectFilesResponseType,
+  AxiosError,
+  PostFormDataType
+>) => {
   return useMutation({
     mutationKey: ["file"],
-    mutationFn: (file: FormData) => postProjectFiles(file),
+    mutationFn: (file: TypedFormData<{ file: File }>) => postProjectFiles(file),
     ...options,
   })
 }

--- a/src/pages/ProjectEditPage/hooks/usePostFileMutation.ts
+++ b/src/pages/ProjectEditPage/hooks/usePostFileMutation.ts
@@ -1,0 +1,15 @@
+import { postProjectFiles } from "@api/projectFile/postProjectFiles"
+import { postProjectFilesResponseType } from "api-models"
+import { AxiosError } from "axios"
+
+import { UseMutationOptions, useMutation } from "@tanstack/react-query"
+
+export const usePostFileMutation = ({
+  ...options
+}: UseMutationOptions<postProjectFilesResponseType, AxiosError, FormData>) => {
+  return useMutation({
+    mutationKey: ["file"],
+    mutationFn: (file: FormData) => postProjectFiles(file),
+    ...options,
+  })
+}

--- a/src/pages/ProjectEditPage/mocks/index.ts
+++ b/src/pages/ProjectEditPage/mocks/index.ts
@@ -3,11 +3,11 @@ import { rest } from "msw"
 import { ENDPOINTS } from "@constants/endPoints"
 
 export const projectEditHandler = [
-  rest.post(ENDPOINTS.UPLOAD_PROJECT_FILES, (req, res, ctx) => {
-    console.log(req)
-    const random = Math.random()
-    return random > 0.5
+  rest.post(ENDPOINTS.UPLOAD_PROJECT_FILES, (_, res, ctx) => {
+    const random = Math.random() * 5000
+    return random > 2500
       ? res(
+          ctx.delay(random),
           ctx.status(200),
           ctx.json({
             fileUrl:
@@ -15,6 +15,7 @@ export const projectEditHandler = [
           }),
         )
       : res(
+          ctx.delay(random),
           ctx.status(400),
           ctx.json({
             status: "BAD_REQUEST",

--- a/src/pages/ProjectEditPage/mocks/index.ts
+++ b/src/pages/ProjectEditPage/mocks/index.ts
@@ -1,0 +1,26 @@
+import { rest } from "msw"
+
+import { ENDPOINTS } from "@constants/endPoints"
+
+export const projectEditHandler = [
+  rest.post(ENDPOINTS.UPLOAD_PROJECT_FILES, (req, res, ctx) => {
+    console.log(req)
+    const random = Math.random()
+    return random > 0.5
+      ? res(
+          ctx.status(200),
+          ctx.json({
+            fileUrl:
+              "https://sidepeek.s3.ap-northeast-2.amazonaws.com/2024/03/05/20/17/00/1.jpg",
+          }),
+        )
+      : res(
+          ctx.status(400),
+          ctx.json({
+            status: "BAD_REQUEST",
+            code: 400,
+            message: "유효하지 않은 요청입니다.",
+          }),
+        )
+  }),
+]

--- a/src/pages/ProjectEditPage/types/FileUploadStateType.ts
+++ b/src/pages/ProjectEditPage/types/FileUploadStateType.ts
@@ -1,0 +1,21 @@
+type SuccessWithData<T> = {
+  isLoading: false
+  error: null
+  data: T
+}
+
+type StartLoading = {
+  isLoading: true
+  error: null
+  data: null
+}
+type WithError = {
+  isLoading: false
+  error: Error
+  data: null
+}
+
+export type FileUploadStateType<T> =
+  | SuccessWithData<T>
+  | StartLoading
+  | WithError

--- a/src/pages/ProjectEditPage/types/PostFormDataType.ts
+++ b/src/pages/ProjectEditPage/types/PostFormDataType.ts
@@ -1,0 +1,3 @@
+import { TypedFormData } from "./TypedFormDataValue"
+
+export type PostFormDataType = TypedFormData<{ file: File }>

--- a/src/pages/ProjectEditPage/types/TypedFormDataValue.ts
+++ b/src/pages/ProjectEditPage/types/TypedFormDataValue.ts
@@ -1,0 +1,86 @@
+type TypedFormDataValue = FormDataEntryValue | Blob
+//FormData를 제네릭처럼 사용하여 객체의 key - value값에 대한 타입을 지정할 수 있음
+/**
+ * Polyfill for FormData Generic
+ *
+ * {@link https://github.com/microsoft/TypeScript/issues/43797}
+ * {@link https://xhr.spec.whatwg.org/#interface-formdata}
+ */
+export interface TypedFormData<T extends Record<string, TypedFormDataValue>> {
+  /**
+   * Appends a new value onto an existing key inside a FormData object, or adds the key if
+   * it does not already exist.
+   *
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/FormData#formdata.append}
+   */
+  append<K extends keyof T>(name: K, value: T[K], fileName?: string): void
+
+  /**
+   * Deletes a key/value pair from a FormData object.
+   *
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/FormData#formdata.delete}
+   */
+  delete(name: keyof T): void
+
+  /**
+   * Returns an iterator allowing to go through all key/value pairs contained in this object.
+   *
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/FormData#formdata.entries}
+   */
+  entries<K extends keyof T>(): IterableIterator<[K, T[K]]>
+
+  /**
+   * Returns the first value associated with a given key from within a FormData object.
+   *
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/FormData#formdata.get}
+   */
+  get<K extends keyof T>(name: K): T[K] | null
+
+  /**
+   * Returns an array of all the values associated with a given key from within a FormData.
+   *
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/FormData#formdata.getall}
+   */
+  getAll<K extends keyof T>(name: K): Array<T[K]>
+
+  /**
+   * Returns a boolean stating whether a FormData object contains a certain key.
+   *
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/FormData#formdata.has}
+   */
+  has(name: keyof T): boolean
+
+  /**
+   * Returns an iterator allowing to go through all keys of the key/value pairs contained in
+   * this object.
+   *
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/FormData#formdata.keys}
+   */
+  keys(): IterableIterator<keyof T>
+
+  /**
+   * Sets a new value for an existing key inside a FormData object, or adds the key/value
+   * if it does not already exist.
+   *
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/FormData#formdata.set}
+   */
+  set(name: keyof T, value: TypedFormDataValue, fileName?: string): void
+
+  /**
+   * Returns an iterator allowing to go through all values contained in this object.
+   *
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/FormData#formdata.values}
+   */
+  values(): IterableIterator<T[keyof T]>
+
+  forEach<K extends keyof T>(
+    callbackfn: (value: T[K], key: K, parent: TypedFormData<T>) => void,
+    thisArg?: unknown,
+  ): void
+}
+
+export function getTypedFormData<T extends Record<string, TypedFormDataValue>>(
+  form?: HTMLFormElement | null,
+): TypedFormData<T> {
+  return new FormData(form || undefined) as unknown as TypedFormData<T>
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
close #101 
<!-- #이슈번호, #이슈번호-->

## 💡 핵심적으로 구현된 사항
- 파일을 업로드 시 API 요청을 보내고 응답을 받습니다. 그동안 상태값(isLoading,Error)이 변화하기 때문에 이 상태값에  따라 UI를 시각적으로 보여줄 수 있습니다.
- 업로드 순서대로 API 요청을 보내는 것이 아니라, 병렬적으로 처리하는 로직을 만들었습니다

## ➕ 그 외에 추가적으로 구현된 사항
- msw rest요청 생성

## 🤔 테스트,검증 && 고민 사항
- 로직 관련해서 자세히 보고 comment 남겨주시면 감사하겠습니다!
- 사실 더 쉽게 할 수 있는 방법이 있을 것 같은데, 뭔가 오류가 계속 나서 완전 베이직한 방법으로 돌아갔습니다... 그러다보니 가독성이 좀 안좋아 진 것 같네요..
- 삭제 관련 로직도 추가하겠습니다
- 처음에는 `useMutation` 을 이용하여 `useMutationState` 를 같이 사용하려 했으나 삭제나 추가 로직의 구현이 좀 힘들 것 같아 일반 API 요청으로 대체했습니다. mutation도 만들어 놓은 상태인데 mutation을 사용하는게 더 좋을까요? 


### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
