### PR TITLE
[hotfix/#116/PermissionError] 인증 api가 아닌 다른 요청에서 401에러를 받는 경우 권한 에러를 생성

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -40,7 +40,7 @@ authInstance.interceptors.request.use(
           return Promise.reject(new LogoutError())
         }
 
-        throw refreshError
+        return Promise.reject(refreshError)
       }
     }
 
@@ -64,7 +64,7 @@ authInstance.interceptors.response.use(
       if (originalRequest && !originalRequest?._retry) {
         originalRequest._retry = true
       } else {
-        return Promise.reject(new LogoutError())
+        return Promise.reject(new PermissionError())
       }
 
       const refreshToken = authToken.getRefreshToken()


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->
close #116 

## 💡 핵심적으로 구현된 사항

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->
- 권한이 없는 요청의 경우도 401에러를 받기때문에 authInstance에서 인증 api로 요청한 경우가 아니면 `PermissionError`를 반환합니다.

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 없음

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- 딱 LogoutError 자리에 PermissionError를 대체하면 됐던 문제였습니다 ㅎㅎㅎ;;
- 인증이 access, refresh 모두 실패하는 경우가 딱 refresh 요청을 하는 순간밖에 없어서 나머지는 `권한 에러`로 대체하면 되더라구요!

