### PR TITLE
[Refactor/#125/RemoveLodash] lodash의 isFunction을 typeof로 대체

### DIFF
--- a/src/components/InputController/InputController.tsx
+++ b/src/components/InputController/InputController.tsx
@@ -9,7 +9,6 @@ import {
   InputProps,
   Spacer,
 } from "@chakra-ui/react"
-import { isFunction } from "lodash"
 
 import { InputControllerProps } from "./types/InputControllerProps"
 
@@ -42,7 +41,7 @@ const InputController = ({
       </Flex>
       {isValidElement(children)
         ? cloneElement(children, renderPorps)
-        : isFunction(children)
+        : typeof children === "function"
           ? children(renderPorps)
           : null}
     </FormControl>


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->
close #125 

## 💡 핵심적으로 구현된 사항

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->
- InputController에서 사용중이던 lodash의 `isFunction`을 typeof 키워드로 대체하였습니다.

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 없음
## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- lodash가 패키지 크기가 상당하여 isFunction만 쓰려고 import 하는건 비효율적이라서 
더 손쉬운 방법인 `typeof`로 대체하였습니다!