### PR TITLE
[feature/#140/UncaughtErrorBoundary] 전역 에러 바운더리 구현

### DIFF
--- a/src/components/ErrorBoundary/AuthErrorBoundary/AuthErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/AuthErrorBoundary/AuthErrorBoundary.tsx
@@ -28,14 +28,12 @@ class AuthErrorBoundary extends Component<AuthErrorBoundaryProps, State> {
   }
 
   static getDerivedStateFromError(error: Error) {
-    // 에러를 잡아서 state를 업데이트하여 다음 렌더링에서 폴백 UI를 보여줄 수 있게 합니다.
     if (isAuthError(error)) {
       return { error }
     }
   }
 
   componentDidCatch(error: Error) {
-    // LogoutError를 받으면 로그아웃합니다.
     if (error instanceof LogoutError) {
       this.props.logout()
     }
@@ -47,19 +45,15 @@ class AuthErrorBoundary extends Component<AuthErrorBoundaryProps, State> {
   }
 
   render() {
-    // Logout이나 Permission 에러가 발생한 경우 모달을 띄웁니다.
-    console.log(this.state.error)
-
     return (
       <>
-        {this.state.error ? (
+        {this.state.error && (
           <ConfirmModal
             onClose={this.handleClose}
             error={this.state.error}
           />
-        ) : (
-          this.props.children
         )}
+        {this.props.children}
       </>
     )
   }

--- a/src/components/ErrorBoundary/ErrorBoundaries.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaries.tsx
@@ -5,17 +5,20 @@ import { QueryErrorResetBoundary } from "@tanstack/react-query"
 import useLogout from "@hooks/useLogout"
 
 import AuthErrorBoundary from "./AuthErrorBoundary/AuthErrorBoundary"
+import UncaughtErrorBoundary from "./UncaughtErrorBoundary/UncaughtErrorBoundary"
 
 const ErrorBoundaries = ({ children }: PropsWithChildren) => {
   const logout = useLogout()
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <AuthErrorBoundary
-          logout={logout}
-          reset={reset}>
-          {children}
-        </AuthErrorBoundary>
+        <UncaughtErrorBoundary reset={reset}>
+          <AuthErrorBoundary
+            logout={logout}
+            reset={reset}>
+            {children}
+          </AuthErrorBoundary>
+        </UncaughtErrorBoundary>
       )}
     </QueryErrorResetBoundary>
   )

--- a/src/components/ErrorBoundary/UncaughtErrorBoundary/UncaughtErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/UncaughtErrorBoundary/UncaughtErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, PropsWithChildren } from "react"
+
+import UncaughtFallback from "./components/UncaughtFallback"
+
+type State = {
+  error: Error | null
+}
+
+interface UncaughtErrorBoundaryProps extends PropsWithChildren {
+  reset: () => void
+}
+
+class UncaughtErrorBoundary extends Component<
+  UncaughtErrorBoundaryProps,
+  State
+> {
+  constructor(props: UncaughtErrorBoundaryProps) {
+    super(props)
+    this.state = {
+      error: null,
+    }
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  handleReset = () => {
+    this.props.reset()
+    this.setState({ error: null })
+  }
+
+  render() {
+    return (
+      <>
+        {this.state.error ? (
+          <UncaughtFallback
+            onReset={this.handleReset}
+            error={this.state.error}
+          />
+        ) : (
+          this.props.children
+        )}
+      </>
+    )
+  }
+}
+
+export default UncaughtErrorBoundary

--- a/src/components/ErrorBoundary/UncaughtErrorBoundary/components/UncaughtFallback.tsx
+++ b/src/components/ErrorBoundary/UncaughtErrorBoundary/components/UncaughtFallback.tsx
@@ -1,0 +1,42 @@
+import { GrPowerReset } from "react-icons/gr"
+import { useNavigate } from "react-router-dom"
+
+import { Center, Icon, IconButton, Text, VStack } from "@chakra-ui/react"
+
+interface UncaughtFallbackProps {
+  error: Error
+  onReset: () => void
+}
+
+const UncaughtFallback = ({ error, onReset }: UncaughtFallbackProps) => {
+  const navigate = useNavigate()
+  return (
+    <Center
+      width="100vw"
+      height="100vh">
+      <VStack gap="5rem">
+        <Text
+          fontFamily="SCDream_Bold"
+          fontSize="8rem">
+          😓 {error.name}
+        </Text>
+        <IconButton
+          aria-label="reset"
+          icon={
+            <Icon
+              as={GrPowerReset}
+              w={20}
+              h={20}
+            />
+          }
+          onClick={() => {
+            onReset()
+            navigate("/")
+          }}
+        />
+      </VStack>
+    </Center>
+  )
+}
+
+export default UncaughtFallback


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->
close #140 

## 💡 핵심적으로 구현된 사항

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->
![image](https://github.com/side-peek/sidepeek_frontend/assets/128919388/50d75ea4-c90b-42aa-853e-e3edf3153853)
- 전역에서 처리되지 않은 에러를 전부 캐치합니다.

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->
- `AuthErrorBoundary`에서 에러가 발생했을때 기존 화면 위에 모달이 보여지는 방식으로 변경하였습니다.
- 
## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- 지금 에러 이름을 그대로 보여주고 있는데 괜찮을까요? 에러 메세지가 아니다보니까 괜찮지 않을까라고 생각했었는데 살짝 보안 이슈가 걱정되긴 합니다 ㅠㅠ
- 혹시 지금 전역에서 에러를 잡는 구조가 이렇게 하는게 맞는 걸까요? 에러 바운더리로 에러 핸들링 하는건 처음이라서 어떤 문제들이 발생할지 잘모르겠습니다...
- 기능상에 문제가 없다면 일단 머지하고 이후에 리팩토링하겠습니다!
