### PR TITLE
[hotfix/#153/CatchLogoutError] AuthErrorBoundary가 로그아웃 에러를 처리할 수 있도록 수정

### DIFF
--- a/src/components/ErrorBoundary/AuthErrorBoundary/AuthErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/AuthErrorBoundary/AuthErrorBoundary.tsx
@@ -47,13 +47,14 @@ class AuthErrorBoundary extends Component<AuthErrorBoundaryProps, State> {
   render() {
     return (
       <>
-        {this.state.error && (
+        {this.state.error ? (
           <ConfirmModal
             onClose={this.handleClose}
             error={this.state.error}
           />
+        ) : (
+          this.props.children
         )}
-        {this.props.children}
       </>
     )
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->
close #153

## 💡 핵심적으로 구현된 사항

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->
- 로그아웃 에러가 지속되는 현상을 수정하였습니다.

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 없음

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- 자식 컴포넌트 위에 에러 안내 모달을 띄우려는 목적으로 만든 컴포넌트였지만 여러가지 예외 케이스에 대한 처리 없이는 사용하기 힘들 것 같아 자식 컴포넌트 대신 모달 자체를 띄우는 방식으로 에러를 처리합니다.