### PR TITLE
[refactor/#193/Pagination] 페이지네이션 리팩토링

### DIFF
--- a/src/components/PaginationRQ/PaginationRQ.tsx
+++ b/src/components/PaginationRQ/PaginationRQ.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from "react"
 
 import { Button } from "@chakra-ui/react"
 
+import useQueryString from "@hooks/useQueryString"
+
 import { MAX_PAGES_COUNT } from "./constants/constants"
 import { moveButtonStyles } from "./styles/moveButtonStyles"
 import { setPageButtonStyles } from "./styles/pageButtonStyles"
@@ -18,15 +20,19 @@ const PaginationRQ = ({
   totalProjectsCount,
   setPage,
 }: PaginationRQProps) => {
-  const [currentPage, setCurrentPage] = useState(() => {
-    const storedPage = localStorage.getItem(`${tab}-page`)
-    return storedPage !== null ? Number(storedPage) : 1
-  })
+  const { navigate, paramsValue: tempPageInfo } = useQueryString("page")
+  const pageInfo =
+    tempPageInfo !== null && isNaN(Number(tempPageInfo))
+      ? 1
+      : Number(tempPageInfo)
+
+  const [currentPage, setCurrentPage] = useState(pageInfo)
 
   const handleSelectPage = (page: number) => {
     localStorage.setItem(`${tab}-page`, page.toString())
     setPage(page)
     setCurrentPage(page)
+    navigate(`?tab=${tab}&page=${page}`)
   }
   const handlePrevPage = () => {
     if (currentPage !== 1) {

--- a/src/components/PaginationRQ/PaginationRQ.tsx
+++ b/src/components/PaginationRQ/PaginationRQ.tsx
@@ -7,24 +7,24 @@ import { moveButtonStyles } from "./styles/moveButtonStyles"
 import { setPageButtonStyles } from "./styles/pageButtonStyles"
 
 interface PaginationRQProps {
-  type: string
+  tab: string
   limit: number
   totalProjectsCount: number
   setPage: React.Dispatch<React.SetStateAction<number>>
 }
 const PaginationRQ = ({
-  type,
+  tab,
   limit,
   totalProjectsCount,
   setPage,
 }: PaginationRQProps) => {
   const [currentPage, setCurrentPage] = useState(() => {
-    const storedPage = localStorage.getItem(`${type}-page`)
+    const storedPage = localStorage.getItem(`${tab}-page`)
     return storedPage !== null ? Number(storedPage) : 1
   })
 
   const handleSelectPage = (page: number) => {
-    localStorage.setItem(`${type}-page`, page.toString())
+    localStorage.setItem(`${tab}-page`, page.toString())
     setPage(page)
     setCurrentPage(page)
   }

--- a/src/components/PaginationRQ/PaginationRQ.tsx
+++ b/src/components/PaginationRQ/PaginationRQ.tsx
@@ -1,0 +1,80 @@
+import { useMemo, useState } from "react"
+
+import { Button } from "@chakra-ui/react"
+
+import { MAX_PAGES_COUNT } from "./constants/constants"
+import { moveButtonStyles } from "./styles/moveButtonStyles"
+import { setPageButtonStyles } from "./styles/pageButtonStyles"
+
+interface PaginationRQProps {
+  type: string
+  limit: number
+  totalProjectsCount: number
+  setPage: React.Dispatch<React.SetStateAction<number>>
+}
+const PaginationRQ = ({
+  type,
+  limit,
+  totalProjectsCount,
+  setPage,
+}: PaginationRQProps) => {
+  const [currentPage, setCurrentPage] = useState(() => {
+    const storedPage = localStorage.getItem(`${type}-page`)
+    return storedPage !== null ? Number(storedPage) : 1
+  })
+
+  const handleSelectPage = (page: number) => {
+    localStorage.setItem(`${type}-page`, page.toString())
+    setPage(page)
+    setCurrentPage(page)
+  }
+  const handlePrevPage = () => {
+    if (currentPage !== 1) {
+      handleSelectPage(currentPage - 1)
+    }
+  }
+  const handleNextPage = () => {
+    if (currentPage !== totalPages) {
+      handleSelectPage(currentPage + 1)
+    }
+  }
+
+  const totalPages = Math.ceil(totalProjectsCount / limit)
+
+  const startPage =
+    currentPage % MAX_PAGES_COUNT === 0
+      ? currentPage - (MAX_PAGES_COUNT - 1)
+      : Math.floor(currentPage / MAX_PAGES_COUNT) * MAX_PAGES_COUNT + 1
+
+  const pages = useMemo(() => {
+    return Array.from(
+      { length: Math.min(MAX_PAGES_COUNT, totalPages - startPage + 1) },
+      (_, idx) => startPage + idx,
+    )
+  }, [startPage, totalPages])
+
+  return (
+    <>
+      <Button
+        {...moveButtonStyles}
+        onClick={handlePrevPage}>
+        이전
+      </Button>
+      {pages.map((page) => (
+        <Button
+          key={page}
+          {...setPageButtonStyles({ isSelected: page === currentPage })}
+          onClick={() => handleSelectPage(page)}>
+          {page}
+        </Button>
+      ))}
+      <Button
+        {...moveButtonStyles}
+        onClick={handleNextPage}>
+        다음
+      </Button>
+    </>
+  )
+}
+
+export default PaginationRQ

--- a/src/components/PaginationRQ/PaginationRQ.tsx
+++ b/src/components/PaginationRQ/PaginationRQ.tsx
@@ -28,6 +28,8 @@ const PaginationRQ = ({
     paramsValue: tempPageInfo,
   } = useQueryString("page")
 
+  const [currentPage, setCurrentPage] = useState(1)
+
   useEffect(() => {
     const pageInfo =
       tempPageInfo !== null && !isNaN(Number(tempPageInfo))
@@ -37,8 +39,6 @@ const PaginationRQ = ({
   }, [location, tempPageInfo])
 
   const { selectPage } = usePageInfoStore((state) => state)
-
-  const [currentPage, setCurrentPage] = useState(1)
 
   const handleSelectPage = (page: number) => {
     selectPage(tab, page)

--- a/src/components/PaginationRQ/PaginationRQ.tsx
+++ b/src/components/PaginationRQ/PaginationRQ.tsx
@@ -1,8 +1,10 @@
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { Button } from "@chakra-ui/react"
 
 import useQueryString from "@hooks/useQueryString"
+
+import usePageInfoStore from "@pages/ProfilePage/stores/usePageInfoStore"
 
 import { MAX_PAGES_COUNT } from "./constants/constants"
 import { moveButtonStyles } from "./styles/moveButtonStyles"
@@ -20,16 +22,26 @@ const PaginationRQ = ({
   totalProjectsCount,
   setPage,
 }: PaginationRQProps) => {
-  const { navigate, paramsValue: tempPageInfo } = useQueryString("page")
-  const pageInfo =
-    tempPageInfo !== null && isNaN(Number(tempPageInfo))
-      ? 1
-      : Number(tempPageInfo)
+  const {
+    location,
+    navigate,
+    paramsValue: tempPageInfo,
+  } = useQueryString("page")
 
-  const [currentPage, setCurrentPage] = useState(pageInfo)
+  useEffect(() => {
+    const pageInfo =
+      tempPageInfo !== null && !isNaN(Number(tempPageInfo))
+        ? Number(tempPageInfo)
+        : 1
+    setCurrentPage(pageInfo)
+  }, [location, tempPageInfo])
+
+  const { selectPage } = usePageInfoStore((state) => state)
+
+  const [currentPage, setCurrentPage] = useState(1)
 
   const handleSelectPage = (page: number) => {
-    localStorage.setItem(`${tab}-page`, page.toString())
+    selectPage(tab, page)
     setPage(page)
     setCurrentPage(page)
     navigate(`?tab=${tab}&page=${page}`)

--- a/src/components/PaginationRQ/constants/constants.ts
+++ b/src/components/PaginationRQ/constants/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_PAGES_COUNT = 10

--- a/src/components/PaginationRQ/styles/moveButtonStyles.ts
+++ b/src/components/PaginationRQ/styles/moveButtonStyles.ts
@@ -1,0 +1,3 @@
+export const moveButtonStyles = {
+  _hover: { bg: "grey.200" },
+}

--- a/src/components/PaginationRQ/styles/pageButtonStyles.ts
+++ b/src/components/PaginationRQ/styles/pageButtonStyles.ts
@@ -1,0 +1,11 @@
+interface SetPageButtonStylesProps {
+  isSelected: boolean
+}
+
+export const setPageButtonStyles = ({
+  isSelected,
+}: SetPageButtonStylesProps) => ({
+  color: isSelected ? "default" : "black.100",
+  bg: isSelected ? "blue.100" : "default",
+  _hover: isSelected ? { bg: "blue.100" } : { bg: "grey.200" },
+})

--- a/src/hooks/useQueryString.ts
+++ b/src/hooks/useQueryString.ts
@@ -4,10 +4,12 @@ const useQueryString = (paramsName: string) => {
   const location = useLocation()
   const navigate = useNavigate()
 
+  console.log(location)
+
   const searchParams = new URLSearchParams(location.search)
   const paramsValue = paramsName && searchParams.get(paramsName)
 
-  return { navigate, paramsValue }
+  return { location, navigate, paramsValue }
 }
 
 export default useQueryString

--- a/src/hooks/useQueryString.ts
+++ b/src/hooks/useQueryString.ts
@@ -4,8 +4,6 @@ const useQueryString = (paramsName: string) => {
   const location = useLocation()
   const navigate = useNavigate()
 
-  console.log(location)
-
   const searchParams = new URLSearchParams(location.search)
   const paramsValue = paramsName && searchParams.get(paramsName)
 

--- a/src/hooks/useQueryString.ts
+++ b/src/hooks/useQueryString.ts
@@ -1,0 +1,13 @@
+import { useLocation, useNavigate } from "react-router-dom"
+
+const useQueryString = (paramsName: string) => {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const searchParams = new URLSearchParams(location.search)
+  const paramsValue = paramsName && searchParams.get(paramsName)
+
+  return { navigate, paramsValue }
+}
+
+export default useQueryString

--- a/src/pages/ProfilePage/components/Projects/Projects.model.ts
+++ b/src/pages/ProfilePage/components/Projects/Projects.model.ts
@@ -18,6 +18,7 @@ export const useUserProjects = ({
   const { data } = useQuery({
     queryKey: ["projects", userId, type, page, size],
     queryFn: () => getUserProjects({ userId, type, page, size }),
+    staleTime: 1000 * 60 * 5,
   })
   return { data }
 }

--- a/src/pages/ProfilePage/components/Projects/Projects.view.tsx
+++ b/src/pages/ProfilePage/components/Projects/Projects.view.tsx
@@ -7,6 +7,8 @@ import {
   useMediaQuery,
 } from "@chakra-ui/react"
 
+import useQueryString from "@hooks/useQueryString"
+
 import { tabsType } from "@pages/ProfilePage/constants/constants"
 import StyledTab from "@pages/ProfilePage/styles/StyledTab"
 
@@ -18,14 +20,31 @@ const ProjectsView = ({ userId, isMe }: UserIdProps) => {
 
   const projectsType = isMe ? ["JOINED", "LIKED", "COMMENTED"] : ["JOINED"]
 
+  const { navigate, paramsValue: tabInfo } = useQueryString("tab")
+  const { paramsValue: tempPageInfo } = useQueryString("page")
+  const pageInfo = Number(tempPageInfo)
+
+  const tabIndex = projectsType.findIndex(
+    (projectType) => projectType === tabInfo,
+  )
+
+  const handleChangeTab = (index: number) => {
+    const storedPage = localStorage.getItem(`${projectsType[index]}-page`)
+    navigate(
+      `?tab=${projectsType[index]}&page=${storedPage !== null ? storedPage : 1}`,
+    )
+  }
+
   return (
     <Box
       height="100%"
       mt="2rem">
       <Tabs
-        size="lg"
+        defaultIndex={tabIndex}
+        variant="enclosed"
         isFitted={!isLargerThan500}
-        variant="enclosed">
+        size="lg"
+        onChange={(index) => handleChangeTab(index)}>
         <TabList
           h="6rem"
           sx={{
@@ -83,6 +102,7 @@ const ProjectsView = ({ userId, isMe }: UserIdProps) => {
               <ProjectsGrid
                 userId={userId}
                 type={type}
+                defaultPage={pageInfo}
               />
             </TabPanel>
           ))}

--- a/src/pages/ProfilePage/components/Projects/Projects.view.tsx
+++ b/src/pages/ProfilePage/components/Projects/Projects.view.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react"
+
 import {
   Box,
   TabList,
@@ -10,6 +12,7 @@ import {
 import useQueryString from "@hooks/useQueryString"
 
 import { tabsType } from "@pages/ProfilePage/constants/constants"
+import usePageInfoStore from "@pages/ProfilePage/stores/usePageInfoStore"
 import StyledTab from "@pages/ProfilePage/styles/StyledTab"
 
 import withUserId, { UserIdProps } from "../HOC/withUserId"
@@ -18,20 +21,28 @@ import ProjectsGrid from "./ProjectsGrid"
 const ProjectsView = ({ userId, isMe }: UserIdProps) => {
   const [isLargerThan500] = useMediaQuery("(min-width: 500px)")
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const projectsType = isMe ? ["JOINED", "LIKED", "COMMENTED"] : ["JOINED"]
 
-  const { navigate, paramsValue: tabInfo } = useQueryString("tab")
+  const { location, navigate, paramsValue: tabInfo } = useQueryString("tab")
   const { paramsValue: tempPageInfo } = useQueryString("page")
   const pageInfo = Number(tempPageInfo)
 
-  const tabIndex = projectsType.findIndex(
-    (projectType) => projectType === tabInfo,
-  )
+  const { tabPageInfo } = usePageInfoStore((state) => state)
+
+  const [tabIndex, setTabIndex] = useState<number>(0)
+
+  useEffect(() => {
+    const newIndex = projectsType.findIndex(
+      (projectType) => projectType === tabInfo,
+    )
+    setTabIndex(newIndex >= 0 ? newIndex : 0)
+  }, [location, projectsType, tabInfo])
 
   const handleChangeTab = (index: number) => {
-    const storedPage = localStorage.getItem(`${projectsType[index]}-page`)
+    const storedPage = tabPageInfo[projectsType[index]]
     navigate(
-      `?tab=${projectsType[index]}&page=${storedPage !== null ? storedPage : 1}`,
+      `?tab=${projectsType[index]}&page=${storedPage !== 0 ? storedPage : 1}`,
     )
   }
 
@@ -40,7 +51,7 @@ const ProjectsView = ({ userId, isMe }: UserIdProps) => {
       height="100%"
       mt="2rem">
       <Tabs
-        defaultIndex={tabIndex}
+        index={tabIndex}
         variant="enclosed"
         isFitted={!isLargerThan500}
         size="lg"

--- a/src/pages/ProfilePage/components/Projects/ProjectsGrid.tsx
+++ b/src/pages/ProfilePage/components/Projects/ProjectsGrid.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 
 import { Center, Grid, GridItem, Text } from "@chakra-ui/react"
 
-import Pagination from "@components/Pagination/Pagination"
+import PaginationRQ from "@components/PaginationRQ/PaginationRQ"
 import ProjectCard from "@components/ProjectCard/ProjectCard"
 
 import { useUserProjects } from "./Projects.model"
@@ -67,7 +67,9 @@ const ProjectsGrid = ({ userId, type }: ProjectsGridProps) => {
               )}
           </Grid>
           <Center my="2rem">
-            <Pagination
+            <PaginationRQ
+              type={type}
+              limit={24}
               totalProjectsCount={totalProjectsCount}
               setPage={setPage}
             />

--- a/src/pages/ProfilePage/components/Projects/ProjectsGrid.tsx
+++ b/src/pages/ProfilePage/components/Projects/ProjectsGrid.tsx
@@ -20,9 +20,10 @@ interface ProjectProperties {
 interface ProjectsGridProps {
   userId: string
   type: string
+  defaultPage: number
 }
-const ProjectsGrid = ({ userId, type }: ProjectsGridProps) => {
-  const [page, setPage] = useState(1)
+const ProjectsGrid = ({ userId, type, defaultPage }: ProjectsGridProps) => {
+  const [page, setPage] = useState(defaultPage)
   const { data } = useUserProjects({
     userId: Number(userId),
     type: type,

--- a/src/pages/ProfilePage/components/Projects/ProjectsGrid.tsx
+++ b/src/pages/ProfilePage/components/Projects/ProjectsGrid.tsx
@@ -68,7 +68,7 @@ const ProjectsGrid = ({ userId, type }: ProjectsGridProps) => {
           </Grid>
           <Center my="2rem">
             <PaginationRQ
-              type={type}
+              tab={type}
               limit={24}
               totalProjectsCount={totalProjectsCount}
               setPage={setPage}

--- a/src/pages/ProfilePage/stores/usePageInfoStore.ts
+++ b/src/pages/ProfilePage/stores/usePageInfoStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand"
 
-interface ITabPageInfo {
+interface TabPageInfoProps {
   [key: string]: number
   JOINED: number
   LIKED: number
@@ -8,7 +8,7 @@ interface ITabPageInfo {
 }
 
 interface PageInfoState {
-  tabPageInfo: ITabPageInfo
+  tabPageInfo: TabPageInfoProps
   selectPage: (tab: string, page: number) => void
 }
 

--- a/src/pages/ProfilePage/stores/usePageInfoStore.ts
+++ b/src/pages/ProfilePage/stores/usePageInfoStore.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand"
+
+interface ITabPageInfo {
+  [key: string]: number
+  JOINED: number
+  LIKED: number
+  COMMENTED: number
+}
+
+interface PageInfoState {
+  tabPageInfo: ITabPageInfo
+  selectPage: (tab: string, page: number) => void
+}
+
+const usePageInfoStore = create<PageInfoState>((set) => ({
+  tabPageInfo: {
+    JOINED: 0,
+    LIKED: 0,
+    COMMENTED: 0,
+  },
+  selectPage: (tab, page) =>
+    set((state) => ({
+      tabPageInfo: {
+        ...state.tabPageInfo,
+        [tab]: page,
+      },
+    })),
+}))
+
+export default usePageInfoStore


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- #이슈번호, #이슈번호-->
close #193 

## 💡 핵심적으로 구현된 사항

<img width="492" alt="스크린샷 2024-04-02 오후 3 58 08" src="https://github.com/side-peek/sidepeek_frontend/assets/124658938/62b6d961-d8c3-4f32-adf9-040e1ddced5f">

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 적어 주세요 -->
- Context API + Tanstack Query 를 활용하여 구현했던 페이지네이션을 Tanstack Query 만을 활용하여 리팩토링 했습니다.
- 렌더링 시 url의 쿼리스트링 tab, page를 초기 상태로서 사용하고, 탭이나 페이지네이션의 페이지를 클릭할 때 실행되는 이벤트 핸들러의 콜백함수로 데이터패칭, navigate를 수행하고, 브라우저의 뒤로가기, 앞으로가기는 location을 의존성 배열 요소로 둔 useEffect 훅을 활용했습니다.
- 사용자 경험 개선
  - 페이지네이션 쿼리의 staleTime을 설정하여 방문한 페이지에 해당하는 데이터를 캐싱합니다. 사용자는 이전에 조회했던 페이지를 열람할 시 네트워크 요청을 하지 않고, 더 빠르게 프로젝트들을 조회할 수 있습니다.
  - 프로필 페이지에는 로그인 여부에 따라 최대 3개의 탭(내, 좋아요한, 댓글단 프로젝트)과 각 탭마다 고유한 페이지네이션이 존재합니다. Zustand 를 활용하여 각 탭의 열람중인 페이지를 저장하고 탭을 이동해도 열람중인 페이지가 유지되도록 구현했습니다.
  - url에 쿼리스트링을 추가했습니다. 사용자는 브라우저의 뒤로가기 버튼을 통해 편리하게 이전 페이지, 혹은 이전 탭으로 돌아갈 수 있습니다. 또한 각 페이지마다 고유한 url을 가지게 되어 검색 엔진 최적화 측면에서의 이점을 가지도록 개선했습니다.

## ➕ 그 외에 추가적으로 구현된 사항

<!-- 없으면 "없음" 이라고 기재해 주세요 -->
<!-- 주 Task 이외의 작업한 변경 사항  -->

## 🤔 테스트,검증 && 고민 사항

<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->

### 📌 PR Comment 작성 시 Prefix for Reviewers

<!-- * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
* P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
* P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore) -->
